### PR TITLE
allow the filtering of the displayed post title

### DIFF
--- a/public/class-owl-carousel-2-public.php
+++ b/public/class-owl-carousel-2-public.php
@@ -226,7 +226,7 @@ class Owl_Carousel_2_Public {
                         $query->the_post();
 
                         // Retrieve Variables
-                        $title = get_the_title();
+                        $title = apply_filters( 'dd_carousel_filter_title', get_the_title(), get_the_ID() );
                         $link = get_the_permalink();
                         $thumb = get_post_thumbnail_id();
                         $output .= '<div class="item"><div class="item-inner">';


### PR DESCRIPTION
Hi,

I'm making a kind of "news ticker" as a carousel for a client and I like your plugin as it allows me to do that easily :) The thing is that only post titles will be displayed on this implementation of your carousel.. There will be no "read more..." button. So I need to put the post permalink on each titles.

For the moment it seems to be not possible as the only hook I may use would be the 'dd_carousel_filter_title_heading' filter but it doesn't pass at least the post ID to get the post permalink. And it is not meant to do anything like that I suppose...

I think a filter on get_the_title would be nice (and so easy to do !), passing by the post ID :) So here it is !

What do you think ?

If you are not ok with that, no problem. If you have another solution in mind, please let me know. I don't want to modify your plugin source code so if you are not interested I will have to digg for another carousel plugin...

Thanks for you time :)

Séb.